### PR TITLE
Fix to work with newer grape validations changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in grape-kaminari.gemspec
 gemspec
+
+gem 'grape', github: 'intridea/grape'
+gem 'pry-byebug'

--- a/lib/grape-kaminari.rb
+++ b/lib/grape-kaminari.rb
@@ -1,7 +1,7 @@
 module Grape
   module Kaminari
     class << self
-      def post_0_9_0_grape
+      def post_0_9_0_grape?
         Gem::Version.new(Grape::VERSION) > Gem::Version.new('0.9.0')
       end
     end

--- a/lib/grape-kaminari.rb
+++ b/lib/grape-kaminari.rb
@@ -1,1 +1,11 @@
+module Grape
+  module Kaminari
+    class << self
+      def post_0_9_0_grape
+        Gem::Version.new(Grape::VERSION) > Gem::Version.new('0.9.0')
+      end
+    end
+  end
+end
+
 require "grape/kaminari"

--- a/lib/grape/kaminari/max_value_validator.rb
+++ b/lib/grape/kaminari/max_value_validator.rb
@@ -1,6 +1,6 @@
 module Grape
   module Kaminari
-    base = if post_0_9_0_grape
+    base = if post_0_9_0_grape?
              Grape::Validations::Base
            else
              Grape::Validations::SingleOptionValidator

--- a/lib/grape/kaminari/max_value_validator.rb
+++ b/lib/grape/kaminari/max_value_validator.rb
@@ -1,6 +1,12 @@
 module Grape
   module Kaminari
-    class MaxValueValidator < Grape::Validations::SingleOptionValidator
+    base = if post_0_9_0_grape
+             Grape::Validations::Base
+           else
+             Grape::Validations::SingleOptionValidator
+           end
+
+    class MaxValueValidator < base
       def validate_param!(attr_name, params)
         return unless params[attr_name]
 

--- a/spec/kaminari_spec.rb
+++ b/spec/kaminari_spec.rb
@@ -23,7 +23,11 @@ describe Grape::Kaminari do
 
     it 'adds to declared parameters' do
       subject.paginate
-      expect(subject.settings[:declared_params]).to eq([:page, :per_page, :offset])
+      if Grape::Kaminari.post_0_9_0_grape
+        expect(subject.inheritable_setting.route[:declared_params]).to eq([:page, :per_page, :offset])
+      else
+        expect(subject.settings[:declared_params]).to eq([:page, :per_page, :offset])
+      end
     end
 
     describe 'descriptions, validation, and defaults' do
@@ -122,7 +126,11 @@ describe Grape::Kaminari do
 
     it 'excludes :offset from declared params' do
       subject.paginate offset: false
-      expect(subject.settings[:declared_params]).not_to include(:offset)
+      if Grape::Kaminari.post_0_9_0_grape
+        expect(subject.inheritable_setting.route[:declared_params]).not_to include(:offset)
+      else
+        expect(subject.settings[:declared_params]).not_to include(:offset)
+      end
     end
 
   end

--- a/spec/kaminari_spec.rb
+++ b/spec/kaminari_spec.rb
@@ -23,7 +23,7 @@ describe Grape::Kaminari do
 
     it 'adds to declared parameters' do
       subject.paginate
-      if Grape::Kaminari.post_0_9_0_grape
+      if Grape::Kaminari.post_0_9_0_grape?
         expect(subject.inheritable_setting.route[:declared_params]).to eq([:page, :per_page, :offset])
       else
         expect(subject.settings[:declared_params]).to eq([:page, :per_page, :offset])
@@ -126,7 +126,7 @@ describe Grape::Kaminari do
 
     it 'excludes :offset from declared params' do
       subject.paginate offset: false
-      if Grape::Kaminari.post_0_9_0_grape
+      if Grape::Kaminari.post_0_9_0_grape?
         expect(subject.inheritable_setting.route[:declared_params]).not_to include(:offset)
       else
         expect(subject.settings[:declared_params]).not_to include(:offset)


### PR DESCRIPTION
This fixes the problem described in issue #20. It retains backwards compatibility with existing versions of Grape.