### PR TITLE
use Kaminari `limit_value` for `X-Per-Page`

### DIFF
--- a/lib/grape/kaminari.rb
+++ b/lib/grape/kaminari.rb
@@ -11,7 +11,7 @@ module Grape
             collection.page(params[:page]).per(params[:per_page]).padding(params[:offset]).tap do |data|
               header "X-Total",       data.total_count.to_s
               header "X-Total-Pages", data.num_pages.to_s
-              header "X-Per-Page",    params[:per_page].to_s
+              header "X-Per-Page",    data.limit_value.to_s
               header "X-Page",        data.current_page.to_s
               header "X-Next-Page",   data.next_page.to_s
               header "X-Prev-Page",   data.prev_page.to_s


### PR DESCRIPTION
will generate a better `X-Per-Page` value if `per_page` param is missing

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/monterail/grape-kaminari/24)
<!-- Reviewable:end -->
