### PR TITLE
Add support for paginate_array

### DIFF
--- a/lib/grape/kaminari.rb
+++ b/lib/grape/kaminari.rb
@@ -19,6 +19,18 @@ module Grape
               header "X-Offset",      params[:offset].to_s
             end
           end
+
+          def paginate_array(array, total)
+            ::Kaminari.paginate_array(array, total_count: total ).page(params[:page]).per(params[:per_page]).tap do |data|
+              header "X-Total",       data.total_count.to_s
+              header "X-Total-Pages", data.num_pages.to_s
+              header "X-Per-Page",    params[:per_page].to_s
+              header "X-Page",        data.current_page.to_s
+              header "X-Next-Page",   data.next_page.to_s
+              header "X-Prev-Page",   data.prev_page.to_s
+              header "X-Offset",      params[:offset].to_s
+            end
+          end
         end
 
         def self.paginate(options = {})


### PR DESCRIPTION
The PR exposes the native Kaminari **paginate_array** as Grape helper. Will you consider this approach for being merged in master?

```ruby
....
paginate_array(my_array, total_count)
....
```

This is useful to keep the header response consistent also when you are dealing with simple array of data.
