### PR TITLE
Use total_pages instead of num_pages as it is deprecated in Kaminari 1.0

### DIFF
--- a/lib/grape/kaminari.rb
+++ b/lib/grape/kaminari.rb
@@ -11,7 +11,7 @@ module Grape
           def paginate(collection)
             collection.page(params[:page]).per(params[:per_page]).padding(params[:offset]).tap do |data|
               header "X-Total",       data.total_count.to_s
-              header "X-Total-Pages", data.num_pages.to_s
+              header "X-Total-Pages", data.total_pages.to_s
               header "X-Per-Page",    data.limit_value.to_s
               header "X-Page",        data.current_page.to_s
               header "X-Next-Page",   data.next_page.to_s


### PR DESCRIPTION
`num_pages` will be deprecated in Kaminari 1.0. For those who use 0.17.0 version of Kaminari deprecation message is thrown. This is a fix.