### PR TITLE
The message should say "less than or equal <number>"

### DIFF
--- a/lib/grape/kaminari/max_value_validator.rb
+++ b/lib/grape/kaminari/max_value_validator.rb
@@ -12,10 +12,11 @@ module Grape
 
         attr = params[attr_name]
         if attr && @option && attr > @option
+          message = "must be less than or equal #{@option}"
           if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.9.0')
-            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "must be less than #{@option}"
+            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message
           else
-            raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message: "must be less than #{@option}"
+            raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message: message
           end
         end
       end

--- a/spec/kaminari_spec.rb
+++ b/spec/kaminari_spec.rb
@@ -112,7 +112,7 @@ describe Grape::Kaminari do
     it 'ensures :per_page is within :max_value' do
       get('/', page: 1, per_page: 1_000)
       expect(last_response.status).to eq 400
-      expect(last_response.body).to match /per_page must be less than 999/
+      expect(last_response.body).to match /per_page must be less than or equal 999/
     end
 
     it 'defaults :offset to customized value' do


### PR DESCRIPTION
The validator is checking whether passed number is greater than an @option,
If this is true then the exception is raised. However when you pass number equal
the @option then exception is not raised. To make the message correct 
it should display "less than _or equal_ <number>" instead of just "less than".