### PR TITLE
Add kaminari-grape as a dependency

### DIFF
--- a/grape-kaminari.gemspec
+++ b/grape-kaminari.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "grape"
   spec.add_runtime_dependency "kaminari"
+  spec.add_runtime_dependency "kaminari-grape"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This is similar to #37, but does not pin the required version, therefore allows the gem to be used with newer rails versions.